### PR TITLE
fixed GitHub URL on gemspec

### DIFF
--- a/jupyter_to_scrapbox.gemspec
+++ b/jupyter_to_scrapbox.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{convert jupyter-notebook to scrapbox-ready-json}
   spec.description   = %q{}
-  spec.homepage      = %q{http://github.com/hsugawa8651/juoyter_to_scrapbox_gem}
+  spec.homepage      = %q{https://github.com/hsugawa8651/jupyter_to_scrapbox_gem}
   spec.licenses      = [ "MIT" ]
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
ここに表示されるURLが間違っていたので修正しました

![](https://gyazo.com/8c436d42b81330f56ac8980a82208f37/raw)